### PR TITLE
fix urls with cshaa change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,29 +1,29 @@
 # Changelog
 
-## [3.0.0](https://github.com/m93a/filtrex/releases/tag/v3.0.0)
+## [3.0.0](https://github.com/cshaa/filtrex/releases/tag/v3.0.0)
 ### Breaking Changes
- * Trying to access properties that aren't present in the `data` object now produces an error ([#22](https://github.com/m93a/filtrex/issues/22))
- * Logical values are no longer converted to `1` and `0`, proper booleans are returned instead ([#27](https://github.com/m93a/filtrex/issues/27))
- * Corrected the precedence of exponentiation ([#41](https://github.com/m93a/filtrex/issues/41), [#43](https://github.com/m93a/filtrex/issues/43))
- * Modulo now always returns a positive number ([#36](https://github.com/m93a/filtrex/issues/36))
- * Removed `random` from standard functions ([#47](https://github.com/m93a/filtrex/issues/47))
- * Corrected the precedence of `not in` ([#42](https://github.com/m93a/filtrex/issues/42))
- * Corrected the precedence of the ternary operator ([#34](https://github.com/m93a/filtrex/issues/34#issuecomment-866426918))
+ * Trying to access properties that aren't present in the `data` object now produces an error ([#22](https://github.com/cshaa/filtrex/issues/22))
+ * Logical values are no longer converted to `1` and `0`, proper booleans are returned instead ([#27](https://github.com/cshaa/filtrex/issues/27))
+ * Corrected the precedence of exponentiation ([#41](https://github.com/cshaa/filtrex/issues/41), [#43](https://github.com/cshaa/filtrex/issues/43))
+ * Modulo now always returns a positive number ([#36](https://github.com/cshaa/filtrex/issues/36))
+ * Removed `random` from standard functions ([#47](https://github.com/cshaa/filtrex/issues/47))
+ * Corrected the precedence of `not in` ([#42](https://github.com/cshaa/filtrex/issues/42))
+ * Corrected the precedence of the ternary operator ([#34](https://github.com/cshaa/filtrex/issues/34#issuecomment-866426918))
 
  ### Deprecations
- * The ternary operator `? :` is now deprecated in favor of `if..then..else` ([#34](https://github.com/m93a/filtrex/issues/34))
- * Modulo operator `%` is now deprecated in favor of `mod` ([#48](https://github.com/m93a/filtrex/issues/48))
+ * The ternary operator `? :` is now deprecated in favor of `if..then..else` ([#34](https://github.com/cshaa/filtrex/issues/34))
+ * Modulo operator `%` is now deprecated in favor of `mod` ([#48](https://github.com/cshaa/filtrex/issues/48))
 
 ### New Features
- * Chained comparisons are now possible: `x>y>z`, meaning `x>y and y>z` ([#37](https://github.com/m93a/filtrex/issues/37))
+ * Chained comparisons are now possible: `x>y>z`, meaning `x>y and y>z` ([#37](https://github.com/cshaa/filtrex/issues/37))
 
- * Operators can now be overloaded using `options.operators['+']` and the like ([#38](https://github.com/m93a/filtrex/issues/30))
+ * Operators can now be overloaded using `options.operators['+']` and the like ([#38](https://github.com/cshaa/filtrex/issues/30))
    * The supported operators are `+`, `-`, `*`, `/`, `mod`, `^`, `==`, `!=`, `<`, `<=`, `>=`, `>`, `~=`
    * The minus operator overload is used for both the binary and the unary operator:
      * `-a` will result in `operators['-'](a)`
      * `a - b` will result in `operators['-'](a, b)`.
 
- * Errors are now i18n-friendly ([#35](https://github.com/m93a/filtrex/issues/35))
+ * Errors are now i18n-friendly ([#35](https://github.com/cshaa/filtrex/issues/35))
    * `err.I18N_STRING` will return one of the following strings:
      * `UNKNOWN_FUNCTION`, English message: “Unknown function: `<funcName>`”
      * `UNKNOWN_PROPERTY`, English message: “Property “`<propName>`” does not exist.”
@@ -32,44 +32,44 @@
      * `INTERNAL`, does not have a standardized message
 
    * The values in angled brackeds are available as properties on the error, eg. `err.funcName` and `err.propName`
-   * Parse errors are sadly not i18n-friendly yet – this is a limitation of Jison ([#55](https://github.com/m93a/filtrex/issues/55))
+   * Parse errors are sadly not i18n-friendly yet – this is a limitation of Jison ([#55](https://github.com/cshaa/filtrex/issues/55))
 
- * Adds `options.constants`, which allows you to pass constant values (like pi) to the user without the need to modify `data` ([#38](https://github.com/m93a/filtrex/issues/38))
+ * Adds `options.constants`, which allows you to pass constant values (like pi) to the user without the need to modify `data` ([#38](https://github.com/cshaa/filtrex/issues/38))
    * When using unquoted symbols, constants shadow data properties, ie. `2*pi` will resolve as `2*constants.pi` if it is defined
    * Quoted symbols always resolve as data properties, ie. `2*'pi'` will always resolve as `2*data.pi`
 
- * Optionally, you use dot as a property accessor ([#44](https://github.com/m93a/filtrex/issues/44#issuecomment-925716818))
-   * The available predefined `prop` functions are:  [`useOptionalChaining`](https://github.com/m93a/filtrex/blob/0d371508b274f78931c990b9ebfa865c9a89b970/src/filtrex.mjs#L121), [`useDotAccessOperator`](https://github.com/m93a/filtrex/blob/0d371508b274f78931c990b9ebfa865c9a89b970/src/filtrex.mjs#L149) and [`useDotAccessOperatorAndOptionalChaining`](https://github.com/m93a/filtrex/blob/0d371508b274f78931c990b9ebfa865c9a89b970/src/filtrex.mjs#L189)
+ * Optionally, you use dot as a property accessor ([#44](https://github.com/cshaa/filtrex/issues/44#issuecomment-925716818))
+   * The available predefined `prop` functions are:  [`useOptionalChaining`](https://github.com/cshaa/filtrex/blob/0d371508b274f78931c990b9ebfa865c9a89b970/src/filtrex.mjs#L121), [`useDotAccessOperator`](https://github.com/cshaa/filtrex/blob/0d371508b274f78931c990b9ebfa865c9a89b970/src/filtrex.mjs#L149) and [`useDotAccessOperatorAndOptionalChaining`](https://github.com/cshaa/filtrex/blob/0d371508b274f78931c990b9ebfa865c9a89b970/src/filtrex.mjs#L189)
    * `customProp` now has additional argument `type: 'unescaped' | 'single-quoted'`
 
 ### How to Migrate from 2.2.0
  * TODO: these will be the steps you need to take for the smoothest ride
 
-## [2.2.0](https://github.com/m93a/filtrex/releases/tag/v2.2.0)
- * The parser is now precompiled, massively speeding up cold start ([#19](https://github.com/m93a/filtrex/issues/19))
- * Fixes Jison dependence ([#21](https://github.com/m93a/filtrex/issues/21))
+## [2.2.0](https://github.com/cshaa/filtrex/releases/tag/v2.2.0)
+ * The parser is now precompiled, massively speeding up cold start ([#19](https://github.com/cshaa/filtrex/issues/19))
+ * Fixes Jison dependence ([#21](https://github.com/cshaa/filtrex/issues/21))
 
-## [2.0.0](https://github.com/m93a/filtrex/releases/tag/v2.0.0)
+## [2.0.0](https://github.com/cshaa/filtrex/releases/tag/v2.0.0)
 
  * **BREAKING CHANGE**: Changes the `compileExpression` method's call signature
    * Previously the method had up to three parameters: `expression`, `extraFunctions` and `customProp`
    * Now the method has two parameters: `expression` and `options`, where `options = { extraFunctions, customProp }`
 
- * **BREAKING CHANGE**: Adds support for quote-escaping in string literals and quoted symbols ([#11](https://github.com/m93a/filtrex/issues/11), [#12](https://github.com/m93a/filtrex/pull/12), [#20](https://github.com/m93a/filtrex/issues/20), [#31j](https://github.com/joewalnes/filtrex/issues/31))
+ * **BREAKING CHANGE**: Adds support for quote-escaping in string literals and quoted symbols ([#11](https://github.com/cshaa/filtrex/issues/11), [#12](https://github.com/cshaa/filtrex/pull/12), [#20](https://github.com/cshaa/filtrex/issues/20), [#31j](https://github.com/joewalnes/filtrex/issues/31))
    * `"some \"quoted\" string and a \\ backslash"`
    * `'a \'quoted\' symbol and a \\ backslash'`
    * backslash `\` character now has to be escaped `\\`
    * these expressions throw a syntax error: `"\'"`, `'\"'`, `"\n"` (use literal newline), `"\anythingother"`
 
- * Adds support for `in` operator with runtime arrays ([#14](https://github.com/m93a/filtrex/issues/14))
+ * Adds support for `in` operator with runtime arrays ([#14](https://github.com/cshaa/filtrex/issues/14))
    *  `value in array` will return `1` when the value is present in the array and `0` otherwise
    *  `array in array` will return `1` when the first array is a subset of the second one, `0` otherwise
    *  `array in value` and `value in value` technically also work, they convert `value` to `[value]`
  
- * Errors are no longer thrown, but instead catched and returned ([#7](https://github.com/m93a/filtrex/issues/7))
+ * Errors are no longer thrown, but instead catched and returned ([#7](https://github.com/cshaa/filtrex/issues/7))
 
 
-## [1.0.0](https://github.com/m93a/filtrex/releases/tag/v1.0.0)
+## [1.0.0](https://github.com/cshaa/filtrex/releases/tag/v1.0.0)
  * **FIXED VULNERABILITY**: Not prone to XSS anymore ([#17j](https://github.com/joewalnes/filtrex/issues/17), [#18j](https://github.com/joewalnes/filtrex/issues/18))
  * **FIXED VULNERABILITY**: More robust against prototype attacks ([#19j](https://github.com/joewalnes/filtrex/pull/19), [#20j](https://github.com/joewalnes/filtrex/pull/20))
  * Adds TypeScript type definitions

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Filtrex
-[![Build Status](https://travis-ci.com/m93a/filtrex.svg?branch=master)](https://travis-ci.com/m93a/filtrex)
+[![Build Status](https://travis-ci.com/cshaa/filtrex.svg?branch=master)](https://travis-ci.com/cshaa/filtrex)
 
 ----
 
-**⚠️ UPGRADING TO v3 ⚠️**: If you're using Filtrex v2 and want to upgrade to the new version, check the [changelog](https://github.com/m93a/filtrex/blob/main/CHANGELOG.md) and [this issue](https://github.com/m93a/filtrex/issues/49). If you need help with the migration, feel free to open an issue.
+**⚠️ UPGRADING TO v3 ⚠️**: If you're using Filtrex v2 and want to upgrade to the new version, check the [changelog](https://github.com/cshaa/filtrex/blob/main/CHANGELOG.md) and [this issue](https://github.com/cshaa/filtrex/issues/49). If you need help with the migration, feel free to open an issue.
 
 ----
 
@@ -20,16 +20,16 @@ Filtrex is available as an NPM package via `yarn add filtrex` or `npm install fi
 import { compileExpression } from 'filtrex';
 const f = compileExpression(`category == "meal"`)
 ```
-You can also get the bundled versions from [`./dist/`](https://github.com/m93a/filtrex/tree/main/dist).
+You can also get the bundled versions from [`./dist/`](https://github.com/cshaa/filtrex/tree/main/dist).
 
 
 ## Why?
 
 There are many cases where you want a user to be able enter an arbitrary expression through a user interface. e.g.
 
-*   Plot a chart ([example](https://m93a.github.io/filtrex/example/plot.html))
-*   Filter/searching across items using multiple fields ([example](https://m93a.github.io/filtrex/example/highlight.html))
-*   Colorize items based on values ([example](https://m93a.github.io/filtrex/example/colorize.html))
+*   Plot a chart ([example](https://cshaa.github.io/filtrex/example/plot.html))
+*   Filter/searching across items using multiple fields ([example](https://cshaa.github.io/filtrex/example/highlight.html))
+*   Colorize items based on values ([example](https://cshaa.github.io/filtrex/example/colorize.html))
 *   Implement a browser based spreadsheet
 
 Sure, you could do that with JavaScript and `eval()`, but I'm sure I don't have to tell you how stupid that would be.
@@ -161,7 +161,7 @@ Error                | A general error, typically thrown by Jison when parsing a
 
 To achieve a good UX, it is recommended to continually validate the user's expression and let them know whether it's well-formed. To achieve this, you can try to build their expression and evaluate it on sample data every few milliseconds – if it either throws or returns an error, display that error to them.
 
-Many errors have a unique `I18N_STRING` to help you translate the message to the user's preferred language. Check [errors.mjs](https://github.com/m93a/filtrex/blob/main/src/errors.mjs) for more info.
+Many errors have a unique `I18N_STRING` to help you translate the message to the user's preferred language. Check [errors.mjs](https://github.com/cshaa/filtrex/blob/main/src/errors.mjs) for more info.
 
 
 ## Custom functions and constants
@@ -279,11 +279,11 @@ Because you can use it to make _**filt**e**r**ing **ex**pressions_ – expressio
 
 **License?**
 
-[MIT](https://github.com/m93a/filtrex/raw/main/LICENSE)
+[MIT](https://github.com/cshaa/filtrex/raw/main/LICENSE)
 
 **Unit tests?**
 
-Here: [Source](https://github.com/m93a/filtrex/tree/main/test)
+Here: [Source](https://github.com/cshaa/filtrex/tree/main/test)
 
 **What happens if the expression is malformed?**
 
@@ -295,7 +295,7 @@ Strings in Filtrex are always double-quoted, like this: `"hello"`, never single-
 
 **Can I use dots as property accessors?**
 
-Yes, you can – using a custom prop function! Since this request is a common one, we even ship the required function with Filtrex – it's called [`useDotAccessOperator`](https://github.com/m93a/filtrex/blob/0d371508b274f78931c990b9ebfa865c9a89b970/src/filtrex.mjs#L149). It is enough to do the following:
+Yes, you can – using a custom prop function! Since this request is a common one, we even ship the required function with Filtrex – it's called [`useDotAccessOperator`](https://github.com/cshaa/filtrex/blob/0d371508b274f78931c990b9ebfa865c9a89b970/src/filtrex.mjs#L149). It is enough to do the following:
 ```typescript
 import {
   compileExpression,
@@ -313,14 +313,14 @@ fn({ foo: { bar: 42 } }) // → 42
 **Can I get rid of the UnknownPropertyError?**
 
 If you want to return `undefined` instead of an error when the user accesses an undefined field, you can use the 
-[`useOptionalChaining`](https://github.com/m93a/filtrex/blob/0d371508b274f78931c990b9ebfa865c9a89b970/src/filtrex.mjs#L121) property function. And if you want to combine it with dots as access operators, use the [`useDotAccessOperatorAndOptionalChaining`](https://github.com/m93a/filtrex/blob/0d371508b274f78931c990b9ebfa865c9a89b970/src/filtrex.mjs#L189) prop function.
+[`useOptionalChaining`](https://github.com/cshaa/filtrex/blob/0d371508b274f78931c990b9ebfa865c9a89b970/src/filtrex.mjs#L121) property function. And if you want to combine it with dots as access operators, use the [`useDotAccessOperatorAndOptionalChaining`](https://github.com/cshaa/filtrex/blob/0d371508b274f78931c990b9ebfa865c9a89b970/src/filtrex.mjs#L189) prop function.
 
 
 Contributors
 ------------
 
 * [@joewalnes](https://github.com/joewalnes) Joe Walnes – the original author of this repository
-* [@m93a](https://github.com/m93a) Michal Grňo – maintainer of the NPM package and the current main developer
+* [@cshaa](https://github.com/cshaa) Michal Grňo – maintainer of the NPM package and the current main developer
 * [@msantos](https://github.com/msantos) Michael Santos – quoted symbols, regex matches and numerous fixes
 * [@bradparks](https://github.com/bradparks) Brad Parks – extensible prop function
 * [@arendjr](https://github.com/arendjr) Arend van Beelen jr. – quote escaping in string literals

--- a/dist/browser/filtrex.js
+++ b/dist/browser/filtrex.js
@@ -2382,7 +2382,7 @@ var filtrex = (function (exports) {
   }( /*#__PURE__*/_wrapNativeSuper(TypeError));
   /**
    * An internal error. This was not meant to happen, please report
-   * at https://github.com/m93a/filtrex/
+   * at https://github.com/cshaa/filtrex/
    *
    * @prop {string} I18N_STRING has the value `'INTERNAL'`
    */

--- a/dist/cjs/filtrex.js
+++ b/dist/cjs/filtrex.js
@@ -2151,7 +2151,7 @@ var UnexpectedTypeError = /*#__PURE__*/function (_TypeError2) {
 }( /*#__PURE__*/_wrapNativeSuper(TypeError));
 /**
  * An internal error. This was not meant to happen, please report
- * at https://github.com/m93a/filtrex/
+ * at https://github.com/cshaa/filtrex/
  *
  * @prop {string} I18N_STRING has the value `'INTERNAL'`
  */

--- a/dist/esm/filtrex.mjs
+++ b/dist/esm/filtrex.mjs
@@ -2145,7 +2145,7 @@ var UnexpectedTypeError = /*#__PURE__*/function (_TypeError2) {
 }( /*#__PURE__*/_wrapNativeSuper(TypeError));
 /**
  * An internal error. This was not meant to happen, please report
- * at https://github.com/m93a/filtrex/
+ * at https://github.com/cshaa/filtrex/
  *
  * @prop {string} I18N_STRING has the value `'INTERNAL'`
  */

--- a/dist/esnext/errors.mjs
+++ b/dist/esnext/errors.mjs
@@ -81,7 +81,7 @@ extends TypeError {
 
 /**
  * An internal error. This was not meant to happen, please report
- * at https://github.com/m93a/filtrex/
+ * at https://github.com/cshaa/filtrex/
  *
  * @prop {string} I18N_STRING has the value `'INTERNAL'`
  */

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "dist/cjs/filtrex.js",
   "types": "dist/esm/filtrex.d.ts",
   "module": "dist/esm/filtrex.mjs",
-  "repository": "git@github.com:m93a/filtrex.git",
+  "repository": "git@github.com:cshaa/filtrex.git",
   "author": "m93a <m93a.cz@gmail.com>",
   "contributors": [
     "albehrens",
@@ -13,7 +13,7 @@
     "arendjr",
     "bradparks",
     "joewalnes",
-    "m93a",
+    "cshaa",
     "msantos"
   ],
   "license": "MIT",

--- a/src/errors.mjs
+++ b/src/errors.mjs
@@ -81,7 +81,7 @@ extends TypeError {
 
 /**
  * An internal error. This was not meant to happen, please report
- * at https://github.com/m93a/filtrex/
+ * at https://github.com/cshaa/filtrex/
  *
  * @prop {string} I18N_STRING has the value `'INTERNAL'`
  */


### PR DESCRIPTION
Looks like a username change broke all the links, found out when an open tab I had for https://m93a.github.io/filtrex/ refreshed to a 404 :p
